### PR TITLE
Fix the wrong action names issue

### DIFF
--- a/lib/payment_test/client.rb
+++ b/lib/payment_test/client.rb
@@ -35,11 +35,11 @@ module Killbill
         end
 
         def set_status_null(methods, options = {})
-          configure('ACTION_RETURN_NIL', nil, methods, options)
+          configure('RETURN_NIL', nil, methods, options)
         end
 
         def reset(methods, options = {})
-          configure('ACTION_RESET', nil, methods, options)
+          configure('ACTION_CLEAR', nil, methods, options)
         end
 
         private
@@ -49,7 +49,7 @@ module Killbill
             'CONFIGURE_ACTION' => action
           }
 
-          body['SLEEP_TIME_SEC'] = arg if action == 'ACTION_RESET'
+          body['SLEEP_TIME_SEC'] = arg if action == 'ACTION_CLEAR'
 
           body['METHODS'] = methods.nil? ? nil : methods.join(',')
 


### PR DESCRIPTION
Here is the following issue: https://github.com/killbill/killbill-payment-test-ui/issues/2
Update the action names following thins enum: https://github.com/killbill/killbill-payment-test-plugin/blob/4aa7b2725a024f5eddc4e472f144bfdd619196dd/src/main/java/org/killbill/billing/plugin/payment/TestingStates.java#L37