### PR TITLE
Rename killbill-assest-ui to killbill_assets_ui

### DIFF
--- a/app/controllers/payment_test/payments_controller.rb
+++ b/app/controllers/payment_test/payments_controller.rb
@@ -39,7 +39,7 @@ module PaymentTest
 
     def set_failed_state
       new_state = params.require(:state)
-      target_method = "set_status_#{new_state.to_s.downcase}".to_sym
+      target_method = "set_status_#{new_state.to_s.downcase}"
 
       begin
         ::Killbill::PaymentTest::PaymentTestClient.send(target_method, nil, options_for_klient)

--- a/lib/payment_test/engine.rb
+++ b/lib/payment_test/engine.rb
@@ -6,7 +6,7 @@
 # We need to explicitly require all of our dependencies listed in payment_test.gemspec
 #
 # See also https://github.com/carlhuda/bundler/issues/49
-require 'killbill-assets-ui'
+require 'killbill_assets_ui'
 require 'killbill_client'
 
 module PaymentTest


### PR DESCRIPTION
Rename killbill-assest-ui to killbill_assets_ui.
Related PR: https://github.com/killbill/killbill-assets-ui/pull/8/files